### PR TITLE
portable-formula: update dependencies for aarch64 Linux

### DIFF
--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -90,12 +90,6 @@ jobs:
           name: bottles_${{matrix.arch}}
           path: bottle
 
-      - name: Post cleanup
-        if: always()
-        run: |
-          brew test-bot --only-cleanup-after
-          rm -rvf bottle portable-ruby
-
       - name: Stop container
         if: always()
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,8 +92,9 @@ jobs:
 
       - name: Test Portable Ruby
         run: |
+          cd
           mkdir -p portable-ruby/
-          tar --strip-components 2 -C portable-ruby -xf bottle/portable-ruby--*.tar.gz
+          tar --strip-components 2 -C portable-ruby -xf '${{github.workspace}}'/bottle/portable-ruby--*.tar.gz
           export PATH="${PWD}/portable-ruby/bin:${PATH}"
           export HOMEBREW_USE_RUBY_FROM_PATH=1
           rm -rf "$(brew --repo)/Library/Homebrew/vendor/portable-ruby"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,12 +99,6 @@ jobs:
           rm -rf "$(brew --repo)/Library/Homebrew/vendor/portable-ruby"
           brew config | awk -v s="${PWD}/portable-ruby/bin/ruby" '$0~s{r=1} 1; END{exit(!r)}'
 
-      - name: Post cleanup
-        if: always()
-        run: |
-          brew test-bot --only-cleanup-after
-          rm -rvf bottle portable-ruby
-
       - name: Stop container
         if: always()
         run: |

--- a/Formula/portable-openssl.rb
+++ b/Formula/portable-openssl.rb
@@ -48,6 +48,15 @@ class PortableOpenssl < PortableFormula
     ]
   end
 
+  def test_args
+    if OS.linux? && Hardware::CPU.arm?
+      # https://github.com/openssl/openssl/issues/17900
+      %w[TESTS=-test_afalg]
+    else
+      []
+    end
+  end
+
   def install
     # OpenSSL is not fully portable and certificate paths are backed into the library.
     # We therefore need to set the certificate path at runtime via an environment variable.
@@ -57,7 +66,7 @@ class PortableOpenssl < PortableFormula
     openssldir.mkpath
     system "perl", "./Configure", *(configure_args + arch_args)
     system "make"
-    system "make", "test"
+    system "make", "test", *test_args
 
     system "make", "install_dev"
 


### PR DESCRIPTION
Also, set cflags and ldflag for portable formulae, and clean them up in `rbconfig.rb` post-build.
